### PR TITLE
add benchmark

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,11 @@ let package = Package(
     ),
     .testTarget(
       name: "GeohashTests",
-      dependencies: ["Geohash"]),
+      dependencies: ["Geohash"]
+    ),
+    .testTarget(
+      name: "BenchmarkTests",
+      dependencies: ["Geohash"]
+    ),
   ]
 )

--- a/Tests/BenchmarkTests/BenchmarkTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkTests.swift
@@ -1,0 +1,34 @@
+//
+//  BenchmarkTests.swift
+//  GeohashTests
+//
+//  Created by michael groble on 9/1/19.
+//
+#if BENCHMARK
+
+import XCTest
+import Geohash
+
+class BenchmarkTests: XCTestCase {
+
+  var bounds: BoundingBox!
+  var n: Int!
+
+  override func setUp() {
+    super.setUp()
+
+    self.bounds = try! GeohashBits.init(hash: "dp3").boundingBox();
+  }
+
+  func testIteration() {
+    self.measure {
+      let iter = try! GeohashIterator.init(bounds: bounds, bitPrecision: 16);
+      self.n = iter.reduce(0, { i, e in
+        i + 1
+      })
+    }
+    XCTAssertEqual(self.n, 131841)
+  }
+}
+
+#endif


### PR DESCRIPTION
  initial results:
  measured [Time, seconds] average: 0.065, relative standard deviation: 1.460%
